### PR TITLE
feat: remove trailing slash in endpoints

### DIFF
--- a/ai4papi/routers/v1/catalog/datasets/zenodo.py
+++ b/ai4papi/routers/v1/catalog/datasets/zenodo.py
@@ -91,7 +91,7 @@ def _zenodo_proxy(
     return r.json()
 
 
-@router.post("/")
+@router.post("")
 def zenodo_proxy(
     api_route: str,
     params: Union[dict, None] = None,

--- a/ai4papi/routers/v1/catalog/modules.py
+++ b/ai4papi/routers/v1/catalog/modules.py
@@ -102,7 +102,7 @@ router = APIRouter(
     responses={404: {"description": "Not found"}},
 )
 router.add_api_route(
-    "/",
+    "",
     Modules.get_filtered_list,
     methods=["GET"],
     )

--- a/ai4papi/routers/v1/catalog/tools.py
+++ b/ai4papi/routers/v1/catalog/tools.py
@@ -79,7 +79,7 @@ router = APIRouter(
     responses={404: {"description": "Not found"}},
 )
 router.add_api_route(
-    "/",
+    "",
     Tools.get_filtered_list,
     methods=["GET"],
     )

--- a/ai4papi/routers/v1/deployments/modules.py
+++ b/ai4papi/routers/v1/deployments/modules.py
@@ -22,7 +22,7 @@ router = APIRouter(
 security = HTTPBearer()
 
 
-@router.get("/")
+@router.get("")
 def get_deployments(
     vos: Union[Tuple, None] = Query(default=None),
     full_info: bool = Query(default=False),
@@ -130,7 +130,7 @@ def get_deployment(
     return job
 
 
-@router.post("/")
+@router.post("")
 def create_deployment(
     vo: str,
     conf: Union[dict, None] = None,

--- a/ai4papi/routers/v1/deployments/tools.py
+++ b/ai4papi/routers/v1/deployments/tools.py
@@ -23,7 +23,7 @@ router = APIRouter(
 security = HTTPBearer()
 
 
-@router.get("/")
+@router.get("")
 def get_deployments(
     vos: Union[Tuple, None] = Query(default=None),
     full_info: bool = Query(default=False),
@@ -132,7 +132,7 @@ def get_deployment(
     return job
 
 
-@router.post("/")
+@router.post("")
 def create_deployment(
     vo: str,
     conf: Union[dict, None] = None,

--- a/ai4papi/routers/v1/secrets.py
+++ b/ai4papi/routers/v1/secrets.py
@@ -105,7 +105,7 @@ def recursive_path_builder(client, kv_list):
     return kv_list
 
 
-@router.get("/")
+@router.get("")
 def get_secrets(
     vo: str,
     subpath: str = '',
@@ -169,7 +169,7 @@ def get_secrets(
     return out
 
 
-@router.post("/")
+@router.post("")
 def create_secret(
     vo: str,
     secret_path: str,
@@ -209,7 +209,7 @@ def create_secret(
     return {'status': 'success'}
 
 
-@router.delete("/")
+@router.delete("")
 def delete_secret(
     vo: str,
     secret_path: str,

--- a/ai4papi/routers/v1/try_me/nomad.py
+++ b/ai4papi/routers/v1/try_me/nomad.py
@@ -19,7 +19,7 @@ router = APIRouter(
 security = HTTPBearer()
 
 
-@router.post("/")
+@router.post("")
 def create_deployment(
     module_name: str,
     authorization=Depends(security),


### PR DESCRIPTION
This PR standardizes the endpoints, because some of them had a trailing slash `/` that was causing PAPI to send redirects when the Dashboard asked for the endpoint without a slash.

With this change, we remove trailing slashes from all endpoints. For example:
* old: `/v1/catalog/modules/`
* new: `/v1/catalog/modules`

This shouldn't break anything, but @MartaOB  can you please cross-check that the Dashboard indeed works fine with this change and no redirects are sent from PAPI?