### PR TITLE
fix: job reschedule on lost

### DIFF
--- a/etc/modules/nomad.hcl
+++ b/etc/modules/nomad.hcl
@@ -78,12 +78,13 @@ job "module-${JOB_UUID}" {
     # * if the node is lost for good, you would need to manually redeploy,
     # * if the node is unavailable due to a network cut, you will recover the job (and
     #   your saved data) once the network comes back.
-    #prevent_reschedule_on_lost = true
+    # We don't want to increase the "lost_after" too much because otherwise we will fail
+    # to identify clients that are failing due to network from clients that are truly down
 
     disconnect {
-      lost_after = "6h"
+      lost_after = "48h"
       replace = false
-      reconcile = "keep_original"
+      reconcile = "keep_original"  # in our case, this is redundant
     }
 
     network {

--- a/etc/modules/nomad.hcl
+++ b/etc/modules/nomad.hcl
@@ -78,7 +78,13 @@ job "module-${JOB_UUID}" {
     # * if the node is lost for good, you would need to manually redeploy,
     # * if the node is unavailable due to a network cut, you will recover the job (and
     #   your saved data) once the network comes back.
-    prevent_reschedule_on_lost = true
+    #prevent_reschedule_on_lost = true
+
+    disconnect {
+      lost_after = "6h"
+      replace = false
+      reconcile = "keep_original"
+    }
 
     network {
 

--- a/etc/tools/ai4os-ai4life-loader/nomad.hcl
+++ b/etc/tools/ai4os-ai4life-loader/nomad.hcl
@@ -85,8 +85,14 @@ job "tool-ai4life-${JOB_UUID}" {
     # * if the node is lost for good, you would need to manually redeploy,
     # * if the node is unavailable due to a network cut, you will recover the job (and
     #   your saved data) once the network comes back.
-    prevent_reschedule_on_lost = true
+    #prevent_reschedule_on_lost = true
 
+    disconnect {
+      lost_after = "6h"
+      replace = false
+      reconcile = "keep_original"
+    }
+    
     network {
 
       port "api" {

--- a/etc/tools/ai4os-ai4life-loader/nomad.hcl
+++ b/etc/tools/ai4os-ai4life-loader/nomad.hcl
@@ -85,14 +85,15 @@ job "tool-ai4life-${JOB_UUID}" {
     # * if the node is lost for good, you would need to manually redeploy,
     # * if the node is unavailable due to a network cut, you will recover the job (and
     #   your saved data) once the network comes back.
-    #prevent_reschedule_on_lost = true
+    # We don't want to increase the "lost_after" too much because otherwise we will fail
+    # to identify clients that are failing due to network from clients that are truly down
 
     disconnect {
-      lost_after = "6h"
+      lost_after = "48h"
       replace = false
-      reconcile = "keep_original"
+      reconcile = "keep_original"  # in our case, this is redundant
     }
-    
+
     network {
 
       port "api" {

--- a/etc/tools/ai4os-cvat/nomad.hcl
+++ b/etc/tools/ai4os-cvat/nomad.hcl
@@ -135,14 +135,15 @@ job "tool-cvat-${JOB_UUID}" {
     # * if the node is lost for good, you would need to manually redeploy,
     # * if the node is unavailable due to a network cut, you will recover the job (and
     #   your saved data) once the network comes back.
-    #prevent_reschedule_on_lost = true
+    # We don't want to increase the "lost_after" too much because otherwise we will fail
+    # to identify clients that are failing due to network from clients that are truly down
 
     disconnect {
-      lost_after = "6h"
+      lost_after = "48h"
       replace = false
-      reconcile = "keep_original"
+      reconcile = "keep_original"  # in our case, this is redundant
     }
-    
+
     ephemeral_disk {
       size = 32768
     }

--- a/etc/tools/ai4os-cvat/nomad.hcl
+++ b/etc/tools/ai4os-cvat/nomad.hcl
@@ -135,8 +135,14 @@ job "tool-cvat-${JOB_UUID}" {
     # * if the node is lost for good, you would need to manually redeploy,
     # * if the node is unavailable due to a network cut, you will recover the job (and
     #   your saved data) once the network comes back.
-    prevent_reschedule_on_lost = true
+    #prevent_reschedule_on_lost = true
 
+    disconnect {
+      lost_after = "6h"
+      replace = false
+      reconcile = "keep_original"
+    }
+    
     ephemeral_disk {
       size = 32768
     }

--- a/etc/tools/ai4os-dev-env/nomad.hcl
+++ b/etc/tools/ai4os-dev-env/nomad.hcl
@@ -85,7 +85,13 @@ job "tool-devenv-${JOB_UUID}" {
     # * if the node is lost for good, you would need to manually redeploy,
     # * if the node is unavailable due to a network cut, you will recover the job (and
     #   your saved data) once the network comes back.
-    prevent_reschedule_on_lost = true
+    #prevent_reschedule_on_lost = true
+    
+    disconnect {
+      lost_after = "6h"
+      replace = false
+      reconcile = "keep_original"
+    }
 
     network {
 

--- a/etc/tools/ai4os-dev-env/nomad.hcl
+++ b/etc/tools/ai4os-dev-env/nomad.hcl
@@ -85,12 +85,13 @@ job "tool-devenv-${JOB_UUID}" {
     # * if the node is lost for good, you would need to manually redeploy,
     # * if the node is unavailable due to a network cut, you will recover the job (and
     #   your saved data) once the network comes back.
-    #prevent_reschedule_on_lost = true
-    
+    # We don't want to increase the "lost_after" too much because otherwise we will fail
+    # to identify clients that are failing due to network from clients that are truly down
+
     disconnect {
-      lost_after = "6h"
+      lost_after = "48h"
       replace = false
-      reconcile = "keep_original"
+      reconcile = "keep_original"  # in our case, this is redundant
     }
 
     network {

--- a/etc/tools/ai4os-federated-server/nomad.hcl
+++ b/etc/tools/ai4os-federated-server/nomad.hcl
@@ -85,14 +85,15 @@ job "tool-fl-${JOB_UUID}" {
     # * if the node is lost for good, you would need to manually redeploy,
     # * if the node is unavailable due to a network cut, you will recover the job (and
     #   your saved data) once the network comes back.
-    #prevent_reschedule_on_lost = true
+    # We don't want to increase the "lost_after" too much because otherwise we will fail
+    # to identify clients that are failing due to network from clients that are truly down
 
     disconnect {
-      lost_after = "6h"
+      lost_after = "48h"
       replace = false
-      reconcile = "keep_original"
+      reconcile = "keep_original"  # in our case, this is redundant
     }
-    
+
     network {
 
       port "fedserver" {

--- a/etc/tools/ai4os-federated-server/nomad.hcl
+++ b/etc/tools/ai4os-federated-server/nomad.hcl
@@ -85,8 +85,14 @@ job "tool-fl-${JOB_UUID}" {
     # * if the node is lost for good, you would need to manually redeploy,
     # * if the node is unavailable due to a network cut, you will recover the job (and
     #   your saved data) once the network comes back.
-    prevent_reschedule_on_lost = true
+    #prevent_reschedule_on_lost = true
 
+    disconnect {
+      lost_after = "6h"
+      replace = false
+      reconcile = "keep_original"
+    }
+    
     network {
 
       port "fedserver" {

--- a/etc/tools/ai4os-llm/nomad.hcl
+++ b/etc/tools/ai4os-llm/nomad.hcl
@@ -85,8 +85,14 @@ job "tool-llm-${JOB_UUID}" {
     # * if the node is lost for good, you would need to manually redeploy,
     # * if the node is unavailable due to a network cut, you will recover the job (and
     #   your saved data) once the network comes back.
-    prevent_reschedule_on_lost = true
+    #prevent_reschedule_on_lost = true
 
+    disconnect {
+      lost_after = "6h"
+      replace = false
+      reconcile = "keep_original"
+    }
+    
     network {
 
         port "ui" {

--- a/etc/tools/ai4os-llm/nomad.hcl
+++ b/etc/tools/ai4os-llm/nomad.hcl
@@ -85,14 +85,15 @@ job "tool-llm-${JOB_UUID}" {
     # * if the node is lost for good, you would need to manually redeploy,
     # * if the node is unavailable due to a network cut, you will recover the job (and
     #   your saved data) once the network comes back.
-    #prevent_reschedule_on_lost = true
+    # We don't want to increase the "lost_after" too much because otherwise we will fail
+    # to identify clients that are failing due to network from clients that are truly down
 
     disconnect {
-      lost_after = "6h"
+      lost_after = "48h"
       replace = false
-      reconcile = "keep_original"
+      reconcile = "keep_original"  # in our case, this is redundant
     }
-    
+
     network {
 
         port "ui" {

--- a/etc/tools/ai4os-nvflare/nomad.hcl
+++ b/etc/tools/ai4os-nvflare/nomad.hcl
@@ -86,12 +86,13 @@ job "tool-nvflare-${JOB_UUID}" {
     # * if the node is lost for good, you would need to manually redeploy,
     # * if the node is unavailable due to a network cut, you will recover the job (and
     #   your saved data) once the network comes back.
-    #prevent_reschedule_on_lost = true
+    # We don't want to increase the "lost_after" too much because otherwise we will fail
+    # to identify clients that are failing due to network from clients that are truly down
 
     disconnect {
-      lost_after = "6h"
+      lost_after = "48h"
       replace = false
-      reconcile = "keep_original"
+      reconcile = "keep_original"  # in our case, this is redundant
     }
 
     network {

--- a/etc/tools/ai4os-nvflare/nomad.hcl
+++ b/etc/tools/ai4os-nvflare/nomad.hcl
@@ -86,7 +86,13 @@ job "tool-nvflare-${JOB_UUID}" {
     # * if the node is lost for good, you would need to manually redeploy,
     # * if the node is unavailable due to a network cut, you will recover the job (and
     #   your saved data) once the network comes back.
-    prevent_reschedule_on_lost = true
+    #prevent_reschedule_on_lost = true
+
+    disconnect {
+      lost_after = "6h"
+      replace = false
+      reconcile = "keep_original"
+    }
 
     network {
 


### PR DESCRIPTION
Adds disconnect block to deployed jobs.

This configuration block ensures that jobs will not be rescheduled on node diconnect. 