### PR TITLE
Update NVFLARE nomad.hcl

### DIFF
--- a/etc/tools/ai4os-nvflare/nomad.hcl
+++ b/etc/tools/ai4os-nvflare/nomad.hcl
@@ -275,7 +275,7 @@ job "tool-nvflare-${JOB_UUID}" {
           --ServerApp.password=`python3 -c "from jupyter_server.auth import passwd; print(passwd('${NVFL_PASSWORD}'))"` \
           --port=8888 \
           --ip=0.0.0.0 \
-          --notebook-dir=/tf \
+          --notebook-dir=/workspace \
           --no-browser \
           --allow-root
         EOF


### PR DESCRIPTION
Change of the jupyterlab notebook dir location from `/tf` to `/workspace`. The `/workspace` directory contains the NVFlare code, which is more convenient to be a default jupyterlab folder instead of the `/tf`, which contains tutorial notebooks on TensorFlow.